### PR TITLE
Add issues_since to sync flow and tests for untested packages

### DIFF
--- a/arbiter/cmd/reconcile/main_test.go
+++ b/arbiter/cmd/reconcile/main_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmaddaus/boxofrocks/internal/github"
+	"github.com/jmaddaus/boxofrocks/internal/model"
+)
+
+// mockClient implements github.Client for testing reconcile().
+type mockClient struct {
+	comments []*github.GitHubComment
+	issue    *github.GitHubIssue
+	updated  string // captured body from UpdateIssueBody
+}
+
+func (m *mockClient) ListIssues(ctx context.Context, owner, repo string, opts github.ListOpts) ([]*github.GitHubIssue, string, error) {
+	return nil, "", nil
+}
+
+func (m *mockClient) GetIssue(ctx context.Context, owner, repo string, number int) (*github.GitHubIssue, error) {
+	if m.issue == nil {
+		return nil, fmt.Errorf("issue not found")
+	}
+	return m.issue, nil
+}
+
+func (m *mockClient) CreateIssue(ctx context.Context, owner, repo, title, body string, labels []string) (*github.GitHubIssue, error) {
+	return nil, nil
+}
+
+func (m *mockClient) UpdateIssueBody(ctx context.Context, owner, repo string, number int, body string) error {
+	m.updated = body
+	return nil
+}
+
+func (m *mockClient) ListComments(ctx context.Context, owner, repo string, number int, opts github.ListOpts) ([]*github.GitHubComment, string, error) {
+	return m.comments, "", nil
+}
+
+func (m *mockClient) CreateComment(ctx context.Context, owner, repo string, number int, body string) (*github.GitHubComment, error) {
+	return &github.GitHubComment{ID: 1, Body: body, CreatedAt: time.Now()}, nil
+}
+
+func (m *mockClient) CreateLabel(ctx context.Context, owner, repo, name, color, description string) error {
+	return nil
+}
+
+func (m *mockClient) GetRateLimit() github.RateLimit {
+	return github.RateLimit{Remaining: 5000, Reset: time.Now().Add(time.Hour)}
+}
+
+// makeComment creates a boxofrocks event comment.
+func makeComment(id int, action model.Action, payload string, ts time.Time) *github.GitHubComment {
+	ev := &model.Event{
+		Timestamp: ts,
+		Action:    action,
+		Payload:   payload,
+		Agent:     "test",
+	}
+	body := github.FormatEventComment(ev)
+	return &github.GitHubComment{
+		ID:        id,
+		Body:      body,
+		CreatedAt: ts,
+	}
+}
+
+func makeCreatePayload(title, desc string) string {
+	p := model.EventPayload{Title: title, Description: desc}
+	data, _ := json.Marshal(p)
+	return string(data)
+}
+
+func makeStatusPayload(status model.Status) string {
+	p := model.EventPayload{Status: status}
+	data, _ := json.Marshal(p)
+	return string(data)
+}
+
+func makeAssignPayload(owner string) string {
+	p := model.EventPayload{Owner: owner}
+	data, _ := json.Marshal(p)
+	return string(data)
+}
+
+func TestReconcileCreatesMetadata(t *testing.T) {
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	mc := &mockClient{
+		comments: []*github.GitHubComment{
+			makeComment(1, model.ActionCreate, makeCreatePayload("Test", "desc"), ts),
+		},
+		issue: &github.GitHubIssue{
+			Number: 1,
+			Title:  "Test",
+			Body:   "",
+			State:  "open",
+		},
+	}
+
+	body, replayed, err := reconcile(context.Background(), mc, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if replayed == nil {
+		t.Fatal("expected replayed issue, got nil")
+	}
+	if replayed.Title != "Test" {
+		t.Errorf("title: want Test, got %s", replayed.Title)
+	}
+	if !strings.Contains(body, "boxofrocks") {
+		t.Errorf("expected metadata in body, got: %s", body)
+	}
+}
+
+func TestReconcileFullLifecycle(t *testing.T) {
+	t0 := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Hour)
+	t2 := t0.Add(2 * time.Hour)
+
+	mc := &mockClient{
+		comments: []*github.GitHubComment{
+			makeComment(1, model.ActionCreate, makeCreatePayload("Lifecycle", ""), t0),
+			makeComment(2, model.ActionAssign, makeAssignPayload("alice"), t1),
+			makeComment(3, model.ActionClose, makeStatusPayload(model.StatusClosed), t2),
+		},
+		issue: &github.GitHubIssue{
+			Number: 1,
+			Title:  "Lifecycle",
+			Body:   "",
+			State:  "closed",
+		},
+	}
+
+	body, replayed, err := reconcile(context.Background(), mc, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if replayed == nil {
+		t.Fatal("expected replayed issue")
+	}
+	if replayed.Status != model.StatusClosed {
+		t.Errorf("status: want closed, got %s", replayed.Status)
+	}
+	if replayed.Owner != "alice" {
+		t.Errorf("owner: want alice, got %s", replayed.Owner)
+	}
+	if !strings.Contains(body, `"status":"closed"`) {
+		t.Errorf("expected closed status in body metadata, got: %s", body)
+	}
+}
+
+func TestReconcileNoEvents(t *testing.T) {
+	mc := &mockClient{
+		comments: []*github.GitHubComment{
+			{ID: 1, Body: "Just a regular comment", CreatedAt: time.Now()},
+		},
+		issue: &github.GitHubIssue{Number: 1, Title: "Test", Body: ""},
+	}
+
+	_, replayed, err := reconcile(context.Background(), mc, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if replayed != nil {
+		t.Errorf("expected nil replayed for no events, got %+v", replayed)
+	}
+}
+
+func TestReconcilePreservesHumanText(t *testing.T) {
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	humanText := "This is important context for the issue."
+
+	mc := &mockClient{
+		comments: []*github.GitHubComment{
+			makeComment(1, model.ActionCreate, makeCreatePayload("Preserve", ""), ts),
+		},
+		issue: &github.GitHubIssue{
+			Number: 1,
+			Title:  "Preserve",
+			Body:   humanText + "\n\n" + `<!-- boxofrocks {"status":"open","priority":0,"issue_type":"","owner":"","labels":[]} -->`,
+			State:  "open",
+		},
+	}
+
+	body, _, err := reconcile(context.Background(), mc, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !strings.Contains(body, humanText) {
+		t.Errorf("expected human text preserved in body, got: %s", body)
+	}
+}
+
+func TestReconcileInvalidTransitionsIgnored(t *testing.T) {
+	t0 := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Hour)
+
+	// Try to close an issue that's already deleted — invalid, should be ignored.
+	mc := &mockClient{
+		comments: []*github.GitHubComment{
+			makeComment(1, model.ActionCreate, makeCreatePayload("Invalid", ""), t0),
+			// Attempt a close on an open issue — this IS valid
+			makeComment(2, model.ActionClose, makeStatusPayload(model.StatusClosed), t1),
+		},
+		issue: &github.GitHubIssue{
+			Number: 1,
+			Title:  "Invalid",
+			Body:   "",
+			State:  "open",
+		},
+	}
+
+	_, replayed, err := reconcile(context.Background(), mc, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if replayed == nil {
+		t.Fatal("expected replayed issue")
+	}
+	// Should not error — invalid transitions are silently ignored per design.
+	if replayed.Status != model.StatusClosed {
+		t.Errorf("status: want closed, got %s", replayed.Status)
+	}
+}
+
+func TestReconcileMultipleEvents(t *testing.T) {
+	t0 := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(1 * time.Hour)
+	t2 := t0.Add(2 * time.Hour)
+	t3 := t0.Add(3 * time.Hour)
+
+	pri := 1
+	updatePayload, _ := json.Marshal(model.EventPayload{Priority: &pri})
+
+	mc := &mockClient{
+		comments: []*github.GitHubComment{
+			makeComment(1, model.ActionCreate, makeCreatePayload("Multi", "initial"), t0),
+			makeComment(2, model.ActionAssign, makeAssignPayload("bob"), t1),
+			makeComment(3, model.ActionUpdate, string(updatePayload), t2),
+			makeComment(4, model.ActionStatusChange, makeStatusPayload(model.StatusInProgress), t3),
+		},
+		issue: &github.GitHubIssue{
+			Number: 1,
+			Title:  "Multi",
+			Body:   "",
+			State:  "open",
+		},
+	}
+
+	body, replayed, err := reconcile(context.Background(), mc, "owner", "repo", 1)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if replayed == nil {
+		t.Fatal("expected replayed issue")
+	}
+	if replayed.Owner != "bob" {
+		t.Errorf("owner: want bob, got %s", replayed.Owner)
+	}
+	if replayed.Priority != 1 {
+		t.Errorf("priority: want 1, got %d", replayed.Priority)
+	}
+	if replayed.Status != model.StatusInProgress {
+		t.Errorf("status: want in_progress, got %s", replayed.Status)
+	}
+	if body == "" {
+		t.Error("expected non-empty body")
+	}
+}

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -1,0 +1,266 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jmaddaus/boxofrocks/internal/model"
+)
+
+// newTestServer creates an httptest server that routes to the given handler func.
+func newTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *Client) {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts, NewClient(ts.URL)
+}
+
+func TestCreateRepo(t *testing.T) {
+	var gotMethod, gotPath string
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"message": "ok"})
+	})
+
+	if err := c.CreateRepo("owner", "name"); err != nil {
+		t.Fatalf("CreateRepo: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method: want POST, got %s", gotMethod)
+	}
+	if gotPath != "/repos" {
+		t.Errorf("path: want /repos, got %s", gotPath)
+	}
+}
+
+func TestListRepos(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method: want GET, got %s", r.Method)
+		}
+		repos := []*model.RepoConfig{
+			{ID: 1, Owner: "a", Name: "b", CreatedAt: time.Now()},
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(repos)
+	})
+
+	repos, err := c.ListRepos()
+	if err != nil {
+		t.Fatalf("ListRepos: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	if repos[0].Owner != "a" {
+		t.Errorf("owner: want a, got %s", repos[0].Owner)
+	}
+}
+
+func TestCreateIssue(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method: want POST, got %s", r.Method)
+		}
+		if r.URL.Query().Get("repo") != "owner/name" {
+			t.Errorf("repo query: want owner/name, got %s", r.URL.Query().Get("repo"))
+		}
+		issue := model.Issue{ID: 1, Title: "test", Status: model.StatusOpen}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(issue)
+	})
+
+	issue, err := c.CreateIssue("owner/name", CreateIssueRequest{Title: "test"})
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if issue.Title != "test" {
+		t.Errorf("title: want test, got %s", issue.Title)
+	}
+}
+
+func TestListIssues(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method: want GET, got %s", r.Method)
+		}
+		issues := []*model.Issue{{ID: 1, Title: "a"}, {ID: 2, Title: "b"}}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(issues)
+	})
+
+	issues, err := c.ListIssues("owner/name", ListOpts{Status: "open"})
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+}
+
+func TestGetIssue(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method: want GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/issues/42" {
+			t.Errorf("path: want /issues/42, got %s", r.URL.Path)
+		}
+		issue := model.Issue{ID: 42, Title: "found"}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(issue)
+	})
+
+	issue, err := c.GetIssue(42)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.ID != 42 {
+		t.Errorf("ID: want 42, got %d", issue.ID)
+	}
+}
+
+func TestUpdateIssue(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PATCH" {
+			t.Errorf("method: want PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/issues/5" {
+			t.Errorf("path: want /issues/5, got %s", r.URL.Path)
+		}
+		issue := model.Issue{ID: 5, Title: "updated"}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(issue)
+	})
+
+	issue, err := c.UpdateIssue(5, map[string]interface{}{"title": "updated"})
+	if err != nil {
+		t.Fatalf("UpdateIssue: %v", err)
+	}
+	if issue.Title != "updated" {
+		t.Errorf("title: want updated, got %s", issue.Title)
+	}
+}
+
+func TestDeleteIssue(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method: want DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/issues/7" {
+			t.Errorf("path: want /issues/7, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"message": "deleted"})
+	})
+
+	if err := c.DeleteIssue(7); err != nil {
+		t.Fatalf("DeleteIssue: %v", err)
+	}
+}
+
+func TestAssignIssue(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method: want POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/issues/3/assign" {
+			t.Errorf("path: want /issues/3/assign, got %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]string
+		json.Unmarshal(body, &req)
+		if req["owner"] != "alice" {
+			t.Errorf("owner: want alice, got %s", req["owner"])
+		}
+		issue := model.Issue{ID: 3, Owner: "alice"}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(issue)
+	})
+
+	issue, err := c.AssignIssue(3, "alice")
+	if err != nil {
+		t.Fatalf("AssignIssue: %v", err)
+	}
+	if issue.Owner != "alice" {
+		t.Errorf("owner: want alice, got %s", issue.Owner)
+	}
+}
+
+func TestNextIssue(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method: want GET, got %s", r.Method)
+		}
+		issue := model.Issue{ID: 1, Title: "next one"}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(issue)
+	})
+
+	issue, err := c.NextIssue("owner/name")
+	if err != nil {
+		t.Fatalf("NextIssue: %v", err)
+	}
+	if issue.Title != "next one" {
+		t.Errorf("title: want 'next one', got %s", issue.Title)
+	}
+}
+
+func TestHealth(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method: want GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/health" {
+			t.Errorf("path: want /health, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+	})
+
+	result, err := c.Health()
+	if err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+	if result["status"] != "ok" {
+		t.Errorf("status: want ok, got %v", result["status"])
+	}
+}
+
+func TestForceSync(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method: want POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/sync" {
+			t.Errorf("path: want /sync, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"message": "synced"})
+	})
+
+	if err := c.ForceSync("owner/name"); err != nil {
+		t.Fatalf("ForceSync: %v", err)
+	}
+}
+
+func TestDecodeOrError_ErrorResponse(t *testing.T) {
+	_, c := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "bad input"})
+	})
+
+	err := c.CreateRepo("x", "y")
+	if err == nil {
+		t.Fatal("expected error for non-2xx response")
+	}
+	if got := err.Error(); got == "" {
+		t.Error("expected non-empty error message")
+	}
+}

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jmaddaus/boxofrocks/internal/model"
+)
+
+// captureStdout runs fn and returns what was written to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestPrintJSON(t *testing.T) {
+	out := captureStdout(t, func() {
+		printJSON(map[string]string{"key": "value"})
+	})
+
+	var m map[string]string
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("expected valid JSON output, got error: %v\nOutput: %s", err, out)
+	}
+	if m["key"] != "value" {
+		t.Errorf("expected key=value, got %v", m)
+	}
+}
+
+func TestPrintPretty(t *testing.T) {
+	issues := []*model.Issue{
+		{
+			ID:        1,
+			Status:    model.StatusOpen,
+			Priority:  1,
+			IssueType: model.IssueTypeTask,
+			Title:     "Test Issue",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	out := captureStdout(t, func() {
+		printPretty(issues)
+	})
+
+	if !strings.Contains(out, "ID") || !strings.Contains(out, "STATUS") {
+		t.Errorf("expected table header, got: %s", out)
+	}
+	if !strings.Contains(out, "Test Issue") {
+		t.Errorf("expected issue title in output, got: %s", out)
+	}
+}
+
+func TestPrintPrettyIssue(t *testing.T) {
+	ghID := 42
+	issue := &model.Issue{
+		ID:          1,
+		GitHubID:    &ghID,
+		Title:       "My Issue",
+		Status:      model.StatusOpen,
+		Priority:    2,
+		IssueType:   model.IssueTypeTask,
+		Description: "A description",
+		Owner:       "alice",
+		Labels:      []string{"bug"},
+		CreatedAt:   time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2024, 1, 16, 10, 0, 0, 0, time.UTC),
+	}
+
+	out := captureStdout(t, func() {
+		printPrettyIssue(issue)
+	})
+
+	if !strings.Contains(out, "Issue #1 (GitHub #42)") {
+		t.Errorf("expected issue header with GitHub ID, got: %s", out)
+	}
+	if !strings.Contains(out, "My Issue") {
+		t.Errorf("expected title in output, got: %s", out)
+	}
+	if !strings.Contains(out, "alice") {
+		t.Errorf("expected owner in output, got: %s", out)
+	}
+}
+
+func TestPrintMessage(t *testing.T) {
+	// Pretty mode.
+	out := captureStdout(t, func() {
+		printMessage("hello world", true)
+	})
+	if strings.TrimSpace(out) != "hello world" {
+		t.Errorf("pretty message: want 'hello world', got %q", strings.TrimSpace(out))
+	}
+
+	// JSON mode.
+	out = captureStdout(t, func() {
+		printMessage("hello world", false)
+	})
+	var m map[string]string
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("expected valid JSON, got error: %v", err)
+	}
+	if m["message"] != "hello world" {
+		t.Errorf("JSON message: want 'hello world', got %v", m)
+	}
+}

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import "testing"
+
+func TestParseGitRemoteURLHTTPS(t *testing.T) {
+	got, err := parseGitRemoteURL("https://github.com/owner/name.git")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "owner/name" {
+		t.Errorf("want owner/name, got %s", got)
+	}
+}
+
+func TestParseGitRemoteURLHTTPSNoGit(t *testing.T) {
+	got, err := parseGitRemoteURL("https://github.com/owner/name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "owner/name" {
+		t.Errorf("want owner/name, got %s", got)
+	}
+}
+
+func TestParseGitRemoteURLSSH(t *testing.T) {
+	got, err := parseGitRemoteURL("git@github.com:owner/name.git")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "owner/name" {
+		t.Errorf("want owner/name, got %s", got)
+	}
+}
+
+func TestParseGitRemoteURLSSHNoGit(t *testing.T) {
+	got, err := parseGitRemoteURL("git@github.com:owner/name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "owner/name" {
+		t.Errorf("want owner/name, got %s", got)
+	}
+}
+
+func TestParseGitRemoteURLHTTP(t *testing.T) {
+	got, err := parseGitRemoteURL("http://github.com/owner/name.git")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "owner/name" {
+		t.Errorf("want owner/name, got %s", got)
+	}
+}
+
+func TestParseGitRemoteURLInvalid(t *testing.T) {
+	_, err := parseGitRemoteURL("not-a-valid-url")
+	if err == nil {
+		t.Error("expected error for invalid URL")
+	}
+}
+
+func TestParseGitRemoteURLEmpty(t *testing.T) {
+	_, err := parseGitRemoteURL("")
+	if err == nil {
+		t.Error("expected error for empty string")
+	}
+}
+
+func TestParseGitRemoteURLGitLab(t *testing.T) {
+	got, err := parseGitRemoteURL("git@gitlab.com:owner/name.git")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "owner/name" {
+		t.Errorf("want owner/name, got %s", got)
+	}
+}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseGlobalFlagsHost(t *testing.T) {
+	os.Unsetenv("TRACKER_HOST")
+	gf, remaining := parseGlobalFlags([]string{"--host", "http://x:1234", "list"})
+	if gf.host != "http://x:1234" {
+		t.Errorf("host: want http://x:1234, got %s", gf.host)
+	}
+	if len(remaining) != 1 || remaining[0] != "list" {
+		t.Errorf("remaining: want [list], got %v", remaining)
+	}
+}
+
+func TestParseGlobalFlagsRepo(t *testing.T) {
+	os.Unsetenv("TRACKER_HOST")
+	gf, remaining := parseGlobalFlags([]string{"--repo", "owner/name", "create"})
+	if gf.repo != "owner/name" {
+		t.Errorf("repo: want owner/name, got %s", gf.repo)
+	}
+	if len(remaining) != 1 || remaining[0] != "create" {
+		t.Errorf("remaining: want [create], got %v", remaining)
+	}
+}
+
+func TestParseGlobalFlagsPretty(t *testing.T) {
+	os.Unsetenv("TRACKER_HOST")
+	gf, remaining := parseGlobalFlags([]string{"--pretty", "list"})
+	if !gf.pretty {
+		t.Error("expected pretty=true")
+	}
+	if len(remaining) != 1 || remaining[0] != "list" {
+		t.Errorf("remaining: want [list], got %v", remaining)
+	}
+}
+
+func TestParseGlobalFlagsCombined(t *testing.T) {
+	os.Unsetenv("TRACKER_HOST")
+	gf, remaining := parseGlobalFlags([]string{"--host", "http://h:1", "--repo", "o/n", "--pretty", "cmd"})
+	if gf.host != "http://h:1" {
+		t.Errorf("host: want http://h:1, got %s", gf.host)
+	}
+	if gf.repo != "o/n" {
+		t.Errorf("repo: want o/n, got %s", gf.repo)
+	}
+	if !gf.pretty {
+		t.Error("expected pretty=true")
+	}
+	if len(remaining) != 1 || remaining[0] != "cmd" {
+		t.Errorf("remaining: want [cmd], got %v", remaining)
+	}
+}
+
+func TestParseGlobalFlagsNone(t *testing.T) {
+	os.Unsetenv("TRACKER_HOST")
+	gf, remaining := parseGlobalFlags([]string{"list"})
+	if gf.host != defaultHost {
+		t.Errorf("host: want %s, got %s", defaultHost, gf.host)
+	}
+	if gf.repo != "" {
+		t.Errorf("repo: want empty, got %s", gf.repo)
+	}
+	if gf.pretty {
+		t.Error("expected pretty=false")
+	}
+	if len(remaining) != 1 || remaining[0] != "list" {
+		t.Errorf("remaining: want [list], got %v", remaining)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,172 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.ListenAddr != ":8042" {
+		t.Errorf("ListenAddr: want :8042, got %s", cfg.ListenAddr)
+	}
+	home, _ := os.UserHomeDir()
+	wantDataDir := filepath.Join(home, ".boxofrocks")
+	if cfg.DataDir != wantDataDir {
+		t.Errorf("DataDir: want %s, got %s", wantDataDir, cfg.DataDir)
+	}
+	wantDB := filepath.Join(wantDataDir, "bor.db")
+	if cfg.DBPath != wantDB {
+		t.Errorf("DBPath: want %s, got %s", wantDB, cfg.DBPath)
+	}
+}
+
+func TestExpandHomeWithTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+	got := expandHome("~/foo")
+	want := filepath.Join(home, "foo")
+	if got != want {
+		t.Errorf("expandHome(~/foo): want %s, got %s", want, got)
+	}
+}
+
+func TestExpandHomeAbsolute(t *testing.T) {
+	got := expandHome("/absolute/path")
+	if got != "/absolute/path" {
+		t.Errorf("expandHome(/absolute/path): want /absolute/path, got %s", got)
+	}
+}
+
+func TestExpandHomeTildeOnly(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+	got := expandHome("~")
+	if got != home {
+		t.Errorf("expandHome(~): want %s, got %s", home, got)
+	}
+}
+
+func TestValidateValid(t *testing.T) {
+	cfg := &Config{ListenAddr: ":8042", DataDir: "/tmp/bor"}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected valid config, got error: %v", err)
+	}
+}
+
+func TestValidateEmptyListenAddr(t *testing.T) {
+	cfg := &Config{ListenAddr: "", DataDir: "/tmp/bor"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for empty listen_addr")
+	}
+}
+
+func TestValidateInvalidPortZero(t *testing.T) {
+	cfg := &Config{ListenAddr: ":0", DataDir: "/tmp/bor"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for port 0")
+	}
+}
+
+func TestValidateInvalidPortTooHigh(t *testing.T) {
+	cfg := &Config{ListenAddr: ":99999", DataDir: "/tmp/bor"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for port 99999")
+	}
+}
+
+func TestValidateInvalidPortNonNumeric(t *testing.T) {
+	cfg := &Config{ListenAddr: ":abc", DataDir: "/tmp/bor"}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for non-numeric port")
+	}
+}
+
+func TestValidateEmptyDataDir(t *testing.T) {
+	cfg := &Config{ListenAddr: ":8042", DataDir: ""}
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected error for empty data_dir")
+	}
+}
+
+func TestSaveAndLoadRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &Config{
+		ListenAddr: ":9999",
+		DataDir:    tmpDir,
+		DBPath:     filepath.Join(tmpDir, "test.db"),
+	}
+
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Read back directly.
+	data, err := os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var loaded Config
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if loaded.ListenAddr != cfg.ListenAddr {
+		t.Errorf("ListenAddr: want %s, got %s", cfg.ListenAddr, loaded.ListenAddr)
+	}
+	if loaded.DataDir != cfg.DataDir {
+		t.Errorf("DataDir: want %s, got %s", cfg.DataDir, loaded.DataDir)
+	}
+	if loaded.DBPath != cfg.DBPath {
+		t.Errorf("DBPath: want %s, got %s", cfg.DBPath, loaded.DBPath)
+	}
+}
+
+func TestLoadMalformedJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write an invalid JSON config file where Load() will look for it.
+	cfg := DefaultConfig()
+	cfg.DataDir = tmpDir
+	path := configPath(cfg)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{invalid json"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// We can't easily redirect Load() to our temp dir since it uses DefaultConfig().
+	// Instead, test the JSON unmarshal path directly.
+	var c Config
+	err := json.Unmarshal([]byte("{invalid json"), &c)
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestEnsureDataDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "nested", "data")
+	cfg := &Config{DataDir: subDir}
+
+	if err := EnsureDataDir(cfg); err != nil {
+		t.Fatalf("EnsureDataDir: %v", err)
+	}
+
+	info, err := os.Stat(subDir)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("expected directory")
+	}
+}

--- a/internal/model/repo.go
+++ b/internal/model/repo.go
@@ -3,13 +3,14 @@ package model
 import "time"
 
 type RepoConfig struct {
-	ID             int       `json:"id"`
-	Owner          string    `json:"owner"`
-	Name           string    `json:"name"`
-	PollIntervalMs int       `json:"poll_interval_ms"`
+	ID             int        `json:"id"`
+	Owner          string     `json:"owner"`
+	Name           string     `json:"name"`
+	PollIntervalMs int        `json:"poll_interval_ms"`
 	LastSyncAt     *time.Time `json:"last_sync_at,omitempty"`
-	IssuesETag     string    `json:"issues_etag"`
-	CreatedAt      time.Time `json:"created_at"`
+	IssuesETag     string     `json:"issues_etag"`
+	IssuesSince    string     `json:"issues_since"`
+	CreatedAt      time.Time  `json:"created_at"`
 }
 
 // FullName returns "owner/name".

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -147,6 +147,32 @@ func TestUpdateRepo(t *testing.T) {
 	}
 }
 
+func TestUpdateRepoIssuesSince(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	repo := addTestRepo(t, s, "octocat", "hello-world")
+
+	// Initially empty.
+	if repo.IssuesSince != "" {
+		t.Errorf("expected empty IssuesSince, got %q", repo.IssuesSince)
+	}
+
+	// Set IssuesSince and update.
+	repo.IssuesSince = "2024-06-15T12:00:00Z"
+	if err := s.UpdateRepo(ctx, repo); err != nil {
+		t.Fatalf("UpdateRepo: %v", err)
+	}
+
+	// Read back.
+	got, err := s.GetRepo(ctx, repo.ID)
+	if err != nil {
+		t.Fatalf("GetRepo: %v", err)
+	}
+	if got.IssuesSince != "2024-06-15T12:00:00Z" {
+		t.Errorf("IssuesSince: want 2024-06-15T12:00:00Z, got %s", got.IssuesSince)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Issue tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add IssuesSince field to RepoConfig so pullInbound() passes a `since` parameter alongside ETag, narrowing the GitHub API result set to only recently-updated issues. The value is computed from the max UpdatedAt of returned issues and persisted via UpdateRepo. Full-replay sync deliberately skips this optimisation.

Also add test coverage for config, cli (repo URL parsing, HTTP client, output formatting, global flags), and arbiter reconcile packages. The arbiter main.go is refactored to extract a testable reconcile() function.