### PR TITLE
Always register local_path on bor init for path-based repo resolution

### DIFF
--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -45,6 +45,10 @@ func TestRunInit_AlreadyRegistered(t *testing.T) {
 			// 409 Conflict — already registered.
 			w.WriteHeader(http.StatusConflict)
 			json.NewEncoder(w).Encode(map[string]string{"error": "already exists"})
+		case r.URL.Path == "/repos" && r.Method == "PATCH":
+			// UpdateRepo for local_path.
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"message": "updated"})
 		case r.URL.Path == "/sync" && r.Method == "POST":
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(map[string]string{"message": "synced"})


### PR DESCRIPTION
Previously local_path was only sent when --socket was passed, which meant X-Working-Dir repo auto-detection didn't work without sockets. Now bor init always captures cwd as local_path, and on 409 (already registered) always updates it. The --socket flag only controls whether the Unix domain socket is created.