### PR TITLE
Hardening and minor CLI update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+<!-- @format -->
+
 # CLAUDE.md - Box of Rocks (`bor`)
 
 ## Project Overview
@@ -40,17 +42,17 @@ model ← (used by all packages)
 
 ### Package Responsibilities
 
-| Package | Role | Has tests |
-|---------|------|-----------|
-| `internal/model` | Data types: Issue, Event, RepoConfig, LocalPathConfig, constants | No |
-| `internal/store` | `Store` interface + SQLite implementation | Yes (39) |
-| `internal/engine` | Pure-logic event replay (`Replay`, `Apply`) | Yes (21) |
-| `internal/github` | GitHub REST API client, auth, body/comment parser, `IsTrustedAuthor` | Yes (37) |
-| `internal/sync` | `SyncManager` + per-repo `RepoSyncer` goroutines, trusted-author filtering | Yes (17) |
-| `internal/daemon` | HTTP server, routes, handlers, middleware, Unix socket lifecycle | Yes (29) |
-| `internal/cli` | CLI commands, HTTP client to daemon, output formatting | No |
-| `internal/config` | `~/.boxofrocks/config.json` management | No |
-| `arbiter/cmd/reconcile` | Standalone binary for GitHub Action | No |
+| Package                 | Role                                                                       | Has tests |
+| ----------------------- | -------------------------------------------------------------------------- | --------- |
+| `internal/model`        | Data types: Issue, Event, RepoConfig, LocalPathConfig, constants           | No        |
+| `internal/store`        | `Store` interface + SQLite implementation                                  | Yes (39)  |
+| `internal/engine`       | Pure-logic event replay (`Replay`, `Apply`)                                | Yes (21)  |
+| `internal/github`       | GitHub REST API client, auth, body/comment parser, `IsTrustedAuthor`       | Yes (37)  |
+| `internal/sync`         | `SyncManager` + per-repo `RepoSyncer` goroutines, trusted-author filtering | Yes (17)  |
+| `internal/daemon`       | HTTP server, routes, handlers, middleware, Unix socket lifecycle           | Yes (29)  |
+| `internal/cli`          | CLI commands, HTTP client to daemon, output formatting                     | No        |
+| `internal/config`       | `~/.boxofrocks/config.json` management                                     | No        |
+| `arbiter/cmd/reconcile` | Standalone binary for GitHub Action                                        | No        |
 
 ## Key Design Patterns
 
@@ -63,6 +65,7 @@ Every mutation (create, update, close, assign, delete) appends an `Event` to the
 ### Handler Pattern (daemon/handlers.go)
 
 All issue-mutation handlers follow this pattern:
+
 1. Resolve repo (query param → X-Repo header → implicit single repo)
 2. Validate input
 3. Generate event with `synced=0`
@@ -82,6 +85,7 @@ Stale/skipped events are silently ignored during replay (not errors). This is in
 ### Sync Flow (sync/syncer.go)
 
 Each `RepoSyncer` poll cycle:
+
 1. **Push outbound:** query `PendingEvents(synced=0)`, post as GitHub comments, mark synced
 2. **Pull inbound:** list GitHub issues with `boxofrocks` label, fetch new comments since `last_comment_id`, filter by `author_association` if `TrustedAuthorsOnly` is enabled, apply incrementally
 3. **Web-created issues:** GitHub issues with `boxofrocks` label but no local match get a synthetic `create` event
@@ -89,6 +93,7 @@ Each `RepoSyncer` poll cycle:
 **Trusted author filtering:** When `RepoConfig.TrustedAuthorsOnly` is true, inbound comments are filtered by `github.IsTrustedAuthor(c.AuthorAssociation)` before processing (both incremental and full replay paths). Trusted associations: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR. Auto-enabled for public repos during `bor init`. The arbiter applies the same filter by checking repo visibility via `GetRepo`.
 
 **Adaptive polling:** Each syncer tracks a `lastActivityAt` timestamp. If a cycle pushes outbound events or receives inbound changes, `lastActivityAt` is reset. Polling uses two tiers:
+
 - **Fast** (5s base, scaled by repo count): used when `lastActivityAt` is within 2 minutes
 - **Slow** (60s): used when idle longer than 2 minutes
 
@@ -151,8 +156,13 @@ Force sync always resets to fast tier. The `SyncStatus.Idle` field reports wheth
 ## Configuration
 
 Default config at `~/.boxofrocks/config.json`:
+
 ```json
-{"listen_addr": ":8042", "data_dir": "~/.boxofrocks", "db_path": "~/.boxofrocks/bor.db"}
+{
+	"listen_addr": ":8042",
+	"data_dir": "~/.boxofrocks",
+	"db_path": "~/.boxofrocks/bor.db"
+}
 ```
 
 `TRACKER_HOST` env var overrides the daemon URL (default `http://127.0.0.1:8042`). Used for Docker containers pointing at `host.docker.internal`.
@@ -162,6 +172,7 @@ Default config at `~/.boxofrocks/config.json`:
 `bor init --socket` registers the working directory as a local path for the repo and enables a Unix domain socket at `.boxofrocks/bor.sock`. Each repo supports multiple local paths (e.g., git worktrees), each with independent socket and file queue. Re-running `bor init` from a different worktree adds a path rather than overwriting.
 
 **Repo resolution chain** (`resolveRepo` in `daemon/handlers.go`):
+
 1. `?repo=` query param
 2. `X-Repo` header
 3. Socket association — `ConnContext` injects repo ID for Unix socket connections
@@ -169,10 +180,12 @@ Default config at `~/.boxofrocks/config.json`:
 5. Single-repo implicit fallback
 
 **Local path management** (`POST /repos/paths`, `DELETE /repos/paths`):
+
 - Paths stored in `repo_local_paths` table (schema v5), globally unique per directory
 - Upserts on conflict — safe to call repeatedly from the same directory
 
 **Socket lifecycle** (in `daemon/daemon.go`):
+
 - `createSocketAtPath(repoID, sockPath)` — creates dir, removes stale socket, listens, serves
 - `startRepoSockets()` — on startup, iterates all `repo.LocalPaths` with `SocketEnabled=true`
 - `socketRepos map[string]int` — maps socket path to repo ID for `ConnContext` lookup
@@ -180,3 +193,42 @@ Default config at `~/.boxofrocks/config.json`:
 ## Auth Chain
 
 Token resolution order: `GITHUB_TOKEN` env → `gh auth token` → `git credential fill`. Daemon starts without a token (sync disabled, local-only mode).
+
+# Task Management (bor)
+
+This project uses `bor` for issue tracking via a file-based queue.
+
+**Setup** — source the helper at the start of your session:
+
+```bash
+source .boxofrocks/bor_api.sh
+```
+
+Before starting work, check for a queued issue:
+
+```bash
+bor_api GET /issues/next
+bor_api POST /issues/<id>/assign '{"owner":"{{AGENT_NAME}}"}'
+bor_api PATCH /issues/<id> '{"status":"in_progress","comment":"starting: brief plan"}'
+
+# At milestones — comment on progress
+bor_api POST /issues/<id>/comment '{"comment":"implemented X, moving to Y"}'
+
+# If blocked
+bor_api PATCH /issues/<id> '{"status":"blocked","comment":"reason"}'
+
+# When ready for review
+bor_api PATCH /issues/<id> '{"status":"in_review","comment":"summary of changes"}'
+
+# When done
+bor_api PATCH /issues/<id> '{"status":"closed","comment":"what was done"}'
+```
+
+If `bor_api` returns a timeout, the daemon may not be running. If next-issue returns 404, proceed with the user's direct request. Do not create issues unless explicitly asked.
+
+Reference:
+
+- List by status: `bor_api GET '/issues?status=open'`
+- Create issue: `bor_api POST /issues '{"title":"..."}'`
+
+Responses: `{"status":<http_code>,"body":<response>}`. Statuses: `open` `in_progress` `blocked` `in_review` `closed`. Types: `task` `bug` `feature` `epic`. Priority: integer, lower = higher.

--- a/arbiter/cmd/reconcile/main_test.go
+++ b/arbiter/cmd/reconcile/main_test.go
@@ -48,6 +48,10 @@ func (m *mockClient) CreateComment(ctx context.Context, owner, repo string, numb
 	return &github.GitHubComment{ID: 1, Body: body, CreatedAt: time.Now()}, nil
 }
 
+func (m *mockClient) AddLabelsToIssue(ctx context.Context, owner, repo string, number int, labels []string) error {
+	return nil
+}
+
 func (m *mockClient) CreateLabel(ctx context.Context, owner, repo, name, color, description string) error {
 	return nil
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -344,3 +344,41 @@ func (c *Client) ForceSync(repo string) error {
 	}
 	return decodeOrError(resp, nil)
 }
+
+// ImportIssues labels all open GitHub issues with "boxofrocks" and triggers a sync.
+func (c *Client) ImportIssues(repo string) (*ImportResult, error) {
+	path := "/repos/import"
+	if repo != "" {
+		path += "?repo=" + repo
+	}
+	resp, err := c.Do("POST", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var result ImportResult
+	if err := decodeOrError(resp, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ImportResult holds the response from the import endpoint.
+type ImportResult struct {
+	Status  string `json:"status"`
+	Repo    string `json:"repo"`
+	Labeled int    `json:"labeled"`
+	Total   int    `json:"total"`
+}
+
+// ForceSyncFull triggers a full replay sync for the given repo.
+func (c *Client) ForceSyncFull(repo string) error {
+	path := "/sync?full=true"
+	if repo != "" {
+		path += "&repo=" + repo
+	}
+	resp, err := c.Do("POST", path, nil)
+	if err != nil {
+		return err
+	}
+	return decodeOrError(resp, nil)
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -121,7 +121,7 @@ func runDaemonBackground(gf globalFlags) error {
 	}
 
 	logPath := daemon.LogFilePath(cfg)
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return fmt.Errorf("open log file: %w", err)
 	}

--- a/internal/cli/repos.go
+++ b/internal/cli/repos.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+)
+
+func runRepos(args []string, gf globalFlags) error {
+	client := newClient(gf)
+
+	repos, err := client.ListRepos()
+	if err != nil {
+		return err
+	}
+
+	if !gf.pretty {
+		printJSON(repos)
+		return nil
+	}
+
+	if len(repos) == 0 {
+		fmt.Println("No repos registered.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "REPO\tTRUSTED\tPATHS\tSOCKET\tQUEUE")
+	for _, repo := range repos {
+		paths := make([]string, 0, len(repo.LocalPaths))
+		hasSocket := false
+		hasQueue := false
+		for _, lp := range repo.LocalPaths {
+			paths = append(paths, lp.LocalPath)
+			if lp.SocketEnabled {
+				hasSocket = true
+			}
+			if lp.QueueEnabled {
+				hasQueue = true
+			}
+		}
+		pathStr := "-"
+		if len(paths) > 0 {
+			pathStr = strings.Join(paths, ", ")
+		}
+		fmt.Fprintf(w, "%s\t%v\t%s\t%v\t%v\n",
+			repo.FullName(),
+			repo.TrustedAuthorsOnly,
+			pathStr,
+			hasSocket,
+			hasQueue,
+		)
+	}
+	w.Flush()
+	return nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -25,6 +25,7 @@ Commands:
   update     Update an issue
   next       Get the next issue to work on
   assign     Assign an issue
+  sync       Trigger a sync with GitHub
   config     Configure repo settings (trusted-authors-only)
   db         Database migration tools (version, check, downgrade)
   help       Show this help
@@ -140,6 +141,8 @@ func Run(args []string, version string) error {
 		return runNext(subArgs, gf)
 	case "assign":
 		return runAssign(subArgs, gf)
+	case "sync":
+		return runSync(subArgs, gf)
 	case "config":
 		return runConfig(subArgs, gf)
 	case "db":

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -26,6 +26,7 @@ Commands:
   next       Get the next issue to work on
   assign     Assign an issue
   sync       Trigger a sync with GitHub
+  repos      List registered repositories
   config     Configure repo settings (trusted-authors-only)
   db         Database migration tools (version, check, downgrade)
   help       Show this help
@@ -143,6 +144,8 @@ func Run(args []string, version string) error {
 		return runAssign(subArgs, gf)
 	case "sync":
 		return runSync(subArgs, gf)
+	case "repos":
+		return runRepos(subArgs, gf)
 	case "config":
 		return runConfig(subArgs, gf)
 	case "db":

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+)
+
+func runSync(args []string, gf globalFlags) error {
+	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
+	full := fs.Bool("full", false, "Perform a full replay sync instead of incremental")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	client := newClient(gf)
+	repo := resolveRepo(gf)
+
+	var err error
+	if *full {
+		err = client.ForceSyncFull(repo)
+	} else {
+		err = client.ForceSync(repo)
+	}
+	if err != nil {
+		return err
+	}
+
+	mode := "incremental"
+	if *full {
+		mode = "full"
+	}
+
+	if gf.pretty {
+		fmt.Printf("Sync triggered (%s).\n", mode)
+	} else {
+		printJSON(map[string]string{
+			"status": "sync triggered",
+			"mode":   mode,
+		})
+	}
+
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,7 +117,7 @@ func Save(cfg *Config) error {
 	}
 
 	path := configPath(cfg)
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 

--- a/internal/daemon/filequeue.go
+++ b/internal/daemon/filequeue.go
@@ -266,7 +266,7 @@ func (d *Daemon) writeQueueResponse(reqPath string, status int, body interface{}
 		return
 	}
 
-	if err := os.WriteFile(tmpPath, respData, 0644); err != nil {
+	if err := os.WriteFile(tmpPath, respData, 0600); err != nil {
 		slog.Warn("file queue write tmp error", "path", tmpPath, "error", err)
 		return
 	}

--- a/internal/daemon/handlers_test.go
+++ b/internal/daemon/handlers_test.go
@@ -621,6 +621,9 @@ func (noopGitHubClient) ListComments(ctx context.Context, owner, repo string, nu
 func (noopGitHubClient) CreateComment(ctx context.Context, owner, repo string, number int, body string) (*github.GitHubComment, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+func (noopGitHubClient) AddLabelsToIssue(ctx context.Context, owner, repo string, number int, labels []string) error {
+	return nil
+}
 func (noopGitHubClient) CreateLabel(ctx context.Context, owner, repo, name, color, description string) error {
 	return nil
 }

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -16,6 +16,7 @@ func (d *Daemon) registerRoutes() *http.ServeMux {
 	mux.HandleFunc("PATCH /repos", d.updateRepo)
 	mux.HandleFunc("POST /repos/paths", d.addRepoPath)
 	mux.HandleFunc("DELETE /repos/paths", d.removeRepoPath)
+	mux.HandleFunc("POST /repos/import", d.importIssues)
 
 	// Issues: register /issues/next BEFORE /issues/{id} so the literal
 	// route matches first.

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -182,6 +182,14 @@ func runMigrations(db *sql.DB) error {
 		}
 	}
 
+	// Replace single-column index with composite index for the actual query pattern.
+	if _, err := db.Exec(`DROP INDEX IF EXISTS idx_events_synced`); err != nil {
+		return fmt.Errorf("drop idx_events_synced: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_events_repo_synced ON events(repo_id, synced)`); err != nil {
+		return fmt.Errorf("create idx_events_repo_synced: %w", err)
+	}
+
 	// Version 5: repo_local_paths junction table for multiple worktrees per repo.
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS repo_local_paths (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -615,4 +615,3 @@ func scanEvent(row scanner) (*model.Event, error) {
 	e.Timestamp, _ = time.Parse(time.RFC3339, ts)
 	return &e, nil
 }
-

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -317,8 +317,9 @@ func (rs *RepoSyncer) cycle(full bool) {
 		if err := rs.ghClient.CreateLabel(ctx, rs.repo.Owner, rs.repo.Name,
 			"boxofrocks", "6f42c1", "Tracked by boxofrocks"); err != nil {
 			slog.Warn("failed to ensure boxofrocks label", "repo", rs.repo.FullName(), "error", err)
+		} else {
+			rs.labelEnsured = true
 		}
-		rs.labelEnsured = true
 	}
 
 	// Push outbound events first.

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -610,6 +611,19 @@ func (rs *RepoSyncer) processGitHubIssue(ctx context.Context, ghIssue *github.Gi
 		}
 	}
 
+	// Reconcile GitHub issue state with local state.
+	// If someone closed/reopened an issue via GitHub's UI (no boxofrocks comment),
+	// we need to detect the state divergence and generate a synthetic event.
+	if full {
+		// After full replay the DB was updated directly; re-read the local issue.
+		if refreshed, err := rs.store.GetIssue(ctx, localIssue.ID); err == nil {
+			localIssue = refreshed
+		}
+	}
+	if err := rs.reconcileGitHubState(ctx, localIssue, ghIssue); err != nil {
+		return fmt.Errorf("reconcile state: %w", err)
+	}
+
 	// Update the sync state with the latest comment.
 	if len(comments) > 0 {
 		last := comments[len(comments)-1]
@@ -620,6 +634,83 @@ func (rs *RepoSyncer) processGitHubIssue(ctx context.Context, ghIssue *github.Gi
 		if err := rs.store.SetIssueSyncState(ctx, rs.repo.ID, ghIssue.Number, lastCommentID, lastCommentAt); err != nil {
 			return fmt.Errorf("set sync state: %w", err)
 		}
+	}
+
+	return nil
+}
+
+// reconcileGitHubState detects when the GitHub issue state (open/closed) diverges
+// from the local issue status and generates a synthetic close or reopen event.
+// This handles cases where someone closes/reopens an issue via GitHub's UI
+// without a [boxofrocks] comment.
+func (rs *RepoSyncer) reconcileGitHubState(ctx context.Context, localIssue *model.Issue, ghIssue *github.GitHubIssue) error {
+	if engine.IsTerminal(localIssue.Status) {
+		return nil // deleted issues are never reconciled
+	}
+
+	now := time.Now().UTC()
+	ghIssueNum := ghIssue.Number
+
+	switch {
+	case ghIssue.State == "closed" && localIssue.Status != model.StatusClosed:
+		// GitHub is closed but local is not — generate a synthetic close event.
+		payload := model.EventPayload{
+			FromStatus: localIssue.Status,
+		}
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal close payload: %w", err)
+		}
+
+		ev := &model.Event{
+			RepoID:            rs.repo.ID,
+			IssueID:           localIssue.ID,
+			GitHubIssueNumber: &ghIssueNum,
+			Timestamp:         now,
+			Action:            model.ActionClose,
+			Payload:           string(payloadJSON),
+			Synced:            1, // originated from GitHub
+		}
+
+		updated, err := engine.Apply(localIssue, ev)
+		if err != nil {
+			return fmt.Errorf("apply close: %w", err)
+		}
+
+		if err := rs.store.UpdateIssue(ctx, updated); err != nil {
+			return fmt.Errorf("update issue: %w", err)
+		}
+		if _, err := rs.store.AppendEvent(ctx, ev); err != nil {
+			return fmt.Errorf("append close event: %w", err)
+		}
+
+		slog.Info("reconciled GitHub close", "repo", rs.repo.FullName(), "issue", localIssue.ID, "github_number", ghIssue.Number)
+
+	case ghIssue.State == "open" && localIssue.Status == model.StatusClosed:
+		// GitHub is open but local is closed — generate a synthetic reopen event.
+		ev := &model.Event{
+			RepoID:            rs.repo.ID,
+			IssueID:           localIssue.ID,
+			GitHubIssueNumber: &ghIssueNum,
+			Timestamp:         now,
+			Action:            model.ActionReopen,
+			Payload:           "{}",
+			Synced:            1,
+		}
+
+		updated, err := engine.Apply(localIssue, ev)
+		if err != nil {
+			return fmt.Errorf("apply reopen: %w", err)
+		}
+
+		if err := rs.store.UpdateIssue(ctx, updated); err != nil {
+			return fmt.Errorf("update issue: %w", err)
+		}
+		if _, err := rs.store.AppendEvent(ctx, ev); err != nil {
+			return fmt.Errorf("append reopen event: %w", err)
+		}
+
+		slog.Info("reconciled GitHub reopen", "repo", rs.repo.FullName(), "issue", localIssue.ID, "github_number", ghIssue.Number)
 	}
 
 	return nil

--- a/internal/sync/syncer_test.go
+++ b/internal/sync/syncer_test.go
@@ -223,6 +223,21 @@ func (m *mockGitHubClient) UpdateIssueState(ctx context.Context, owner, repo str
 	return fmt.Errorf("issue %d not found", number)
 }
 
+func (m *mockGitHubClient) AddLabelsToIssue(ctx context.Context, owner, repo string, number int, labels []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := m.repoKey(owner, repo)
+	for i, iss := range m.issues[key] {
+		if iss.Number == number {
+			for _, label := range labels {
+				m.issues[key][i].Labels = append(m.issues[key][i].Labels, github.GitHubLabel{Name: label})
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("issue %d not found", number)
+}
+
 func (m *mockGitHubClient) GetRepo(ctx context.Context, owner, repo string) (*github.GitHubRepo, error) {
 	return &github.GitHubRepo{Private: true}, nil
 }


### PR DESCRIPTION
---                                                                                                                              
Hardening, sync improvements, and new CLI commands
                                                                                                                           
Summary                                                                        

- Harden security with request body size limits, input validation, and SQL injection prevention across daemon handlers and store
- Simplify handler and store code by removing redundant patterns
- Reconcile GitHub issue open/closed state on inbound sync so local status stays consistent with GitHub
- Add bor sync command with --full flag for on-demand sync
- Add --import-all flag on bor init to label existing GitHub issues for tracking
- Trigger immediate outbound sync after every mutation so events push without waiting for the next poll cycle
- Exclude closed issues from default bor list output (use --all or --status closed)
- Add bor repos command to list registered repositories

Breaking changes

- bor list no longer shows closed issues by default — scripts relying on this need --all or --status closed
- github.Client interface gains AddLabelsToIssue method (internal only)

New CLI commands

- bor sync [--full] — trigger incremental or full replay sync
- bor repos — list registered repos with paths, socket/queue flags

New flags

- bor init --import-all — label all open GitHub issues with boxofrocks during init

New endpoints

- POST /repos/import — label and import existing GitHub issues
- POST /sync?full=true — full replay sync variant

